### PR TITLE
(GH-72) Add support for build identifiers 

### DIFF
--- a/Cake.Issues.Recipe/Content/build.cake
+++ b/Cake.Issues.Recipe/Content/build.cake
@@ -85,7 +85,15 @@ IssuesBuildTasks.CreateFullIssuesReportTask = Task("Create-FullIssuesReport")
     .IsDependentOn("Read-Issues")
     .Does<IssuesData>((data) =>
 {
-    data.FullIssuesReport = IssuesParameters.OutputDirectory.CombineWithFilePath("report.html");
+    var reportFileName = "report";
+    if (!string.IsNullOrWhiteSpace(IssuesParameters.BuildIdentifier))
+    {
+        reportFileName += $"-{IssuesParameters.BuildIdentifier}";
+    }
+    reportFileName += ".html";
+
+    data.FullIssuesReport =
+        IssuesParameters.OutputDirectory.CombineWithFilePath(reportFileName);
     EnsureDirectoryExists(IssuesParameters.OutputDirectory);
 
     // Create HTML report using DevExpress template.

--- a/Cake.Issues.Recipe/Content/parameters/IssuesParameters.cake
+++ b/Cake.Issues.Recipe/Content/parameters/IssuesParameters.cake
@@ -11,6 +11,14 @@ public static class IssuesParameters
     public static DirectoryPath OutputDirectory { get; set; } = "BuildArtifacts";
 
     /// <summary>
+    /// Gets or sets a identifier for the build run.
+    /// If set this identifier will be used to identify to artifacts provided by the
+    /// build if building on multiple configurations.
+    /// Default value is <c>string.Empty</c>.
+    /// </summary>
+    public static string BuildIdentifier { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets the parameters for the input files.
     /// </summary>
     public static IssuesParametersInputFiles InputFiles { get; } = new IssuesParametersInputFiles();

--- a/Cake.Issues.Recipe/Content/tasks/buildservers/AzureDevOpsBuildServer.cake
+++ b/Cake.Issues.Recipe/Content/tasks/buildservers/AzureDevOpsBuildServer.cake
@@ -63,7 +63,13 @@ public class AzureDevOpsBuildServer : BaseBuildServer
             throw new ArgumentNullException(nameof(data));
         }
 
-        var summaryFile = IssuesParameters.OutputDirectory.CombineWithFilePath("summary.md");
+        var summaryFileName = "summary";
+        if (!string.IsNullOrWhiteSpace(IssuesParameters.BuildIdentifier))
+        {
+            summaryFileName += $"-{IssuesParameters.BuildIdentifier}";
+        }
+        summaryFileName += ".md";
+        var summaryFilePath = IssuesParameters.OutputDirectory.CombineWithFilePath(summaryFileName);
 
         // Create summary for Azure Pipelines using custom template.
         context.CreateIssueReport(
@@ -71,9 +77,9 @@ public class AzureDevOpsBuildServer : BaseBuildServer
             context.GenericIssueReportFormatFromFilePath(
                 new FilePath(sourceFilePath).GetDirectory().Combine("tasks").Combine("buildservers").CombineWithFilePath("AzurePipelineSummary.cshtml")),
             data.RepositoryRootDirectory,
-            summaryFile);
+            summaryFilePath);
 
-        context.TFBuild().Commands.UploadTaskSummary(summaryFile);
+        context.TFBuild().Commands.UploadTaskSummary(summaryFilePath);
     }
 
     /// <inheritdoc />

--- a/Cake.Issues.Recipe/Content/tasks/pullrequestsystems/AzureDevOpsPullRequestSystem.cake
+++ b/Cake.Issues.Recipe/Content/tasks/pullrequestsystems/AzureDevOpsPullRequestSystem.cake
@@ -56,16 +56,26 @@ public class AzureDevOpsPullRequestSystem : BasePullRequestSystem
                 data.BuildServer.DeterminePullRequestId(context).Value,
                 context.TfsAuthenticationOAuth(context.EnvironmentVariable("SYSTEM_ACCESSTOKEN")));
 
-        var pullRequstStatus =
-            new TfsPullRequestStatus("Issues")
+        var pullRequestStatusName = "Issues";
+        var pullRequestDescriptionIfIssues = $"Found {data.Issues.Count()} issues";
+        var pullRequestDescriptionIfNoIssues = "No issues found";
+        if (!string.IsNullOrWhiteSpace(IssuesParameters.BuildIdentifier))
+        {
+            pullRequestStatusName += $"-{IssuesParameters.BuildIdentifier}";
+            pullRequestDescriptionIfIssues += $" for build {IssuesParameters.BuildIdentifier}";
+            pullRequestDescriptionIfNoIssues += $" for build {IssuesParameters.BuildIdentifier}";
+        }
+
+        var pullRequestStatus =
+            new TfsPullRequestStatus(pullRequestStatusName)
             {
                 Genre = "Cake.Issues.Recipe",
                 State = data.Issues.Any() ? TfsPullRequestStatusState.Failed : TfsPullRequestStatusState.Succeeded,
-                Description = data.Issues.Any() ? $"Found {data.Issues.Count()} issues" : "No issues found"
+                Description = data.Issues.Any() ? pullRequestDescriptionIfIssues : pullRequestDescriptionIfNoIssues
             };
 
         context.TfsSetPullRequestStatus(
             pullRequestSettings,
-            pullRequstStatus);
+            pullRequestStatus);
         }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,9 +9,10 @@ and behavior of Cake.Issues.Recipe.
 
 # General
 
-| Property                                           | Default Value    | Description                                                                                      |
-|----------------------------------------------------|------------------|--------------------------------------------------------------------------------------------------|
-| `IssuesParameters.OutputDirectory`                 | `BuildArtifacts` | Path to the output directory. A relative path will be relative to the current working directory. |
+| Property                                           | Default Value    | Description                                                                                                                                              |
+|----------------------------------------------------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `IssuesParameters.OutputDirectory`                 | `BuildArtifacts` | Path to the output directory. A relative path will be relative to the current working directory.                                                         |
+| `IssuesParameters.BuildIdentifier`                 | `string.Empty`   | Identifier for the build run. If set this identifier will be used to identify to artifacts provided by the build if building on multiple configurations. |
 
 # Input files
 


### PR DESCRIPTION
Add support for defining build identifiers which are used for file name of full report and summary report, and also for name of pull request status.

Fixes #72