### PR TITLE
(GH-91) Give BuildMetaData a unique name

### DIFF
--- a/Cake.Issues.Recipe/Content/build.cake
+++ b/Cake.Issues.Recipe/Content/build.cake
@@ -19,7 +19,7 @@ var IssuesBuildTasks = new IssuesBuildTaskDefinitions();
 
 Setup<IssuesData>(setupContext =>
 {
-    Information("Initializing Cake.Issues.Recipe (Version {0})...", BuildMetaData.Version);
+    Information("Initializing Cake.Issues.Recipe (Version {0})...", BuildMetaDataCakeIssuesRecipe.Version);
     return new IssuesData(setupContext);
 });
 

--- a/setup.cake
+++ b/setup.cake
@@ -27,7 +27,7 @@ ToolSettings.SetToolSettings(context: Context);
 Task("Generate-Version-File")
     .Does(() => {
         var buildMetaDataCodeGen = TransformText(@"
-        public class BuildMetaData
+        public class BuildMetaDataCakeIssuesRecipe
         {
             public static string Date { get; } = ""<%date%>"";
             public static string Version { get; } = ""<%version%>"";


### PR DESCRIPTION
Renames BuildMetaData to BuildMetaDataCakeIssuesRecipe

Fixes #91 