### PR TITLE
(GH-98) Don't throw exception if no files are passed for analyzing

### DIFF
--- a/Cake.Issues.Recipe/Content/build.cake
+++ b/Cake.Issues.Recipe/Content/build.cake
@@ -65,6 +65,12 @@ IssuesBuildTasks.ReadIssuesTask = Task("Read-Issues")
                 IssuesParameters.InputFiles.InspectCodeLogFilePath));
     }
 
+    if (!issueProviders.Any())
+    {
+        Information("No files to process...");
+        return;
+    }
+
     // Read issues from log files.
     data.AddIssues(
         ReadIssues(


### PR DESCRIPTION
Don't throw exception if no files are passed for analyzing

Fixes #98 