### PR TITLE
(GH-6) Add support for markdownlint

### DIFF
--- a/Cake.Issues.Recipe/Content/build.cake
+++ b/Cake.Issues.Recipe/Content/build.cake
@@ -73,6 +73,14 @@ IssuesBuildTasks.ReadIssuesTask = Task("Read-Issues")
                 MarkdownlintCliLogFileFormat));
     }
 
+    if (IssuesParameters.InputFiles.MarkdownlintV1LogFilePath != null)
+    {
+        issueProviders.Add(
+            MarkdownlintIssuesFromFilePath(
+                IssuesParameters.InputFiles.MarkdownlintV1LogFilePath,
+                MarkdownlintLogFileFormat));
+    }
+
     if (!issueProviders.Any())
     {
         Information("No files to process...");

--- a/Cake.Issues.Recipe/Content/parameters/IssuesParametersInputFiles.cake
+++ b/Cake.Issues.Recipe/Content/parameters/IssuesParametersInputFiles.cake
@@ -22,4 +22,9 @@ public class IssuesParametersInputFiles
     /// Gets or sets the path to the markdownlint-cli log file.
     /// </summary>
     public FilePath MarkdownlintCliLogFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the markdownlint log file in version 1.
+    /// </summary>
+    public FilePath MarkdownlintV1LogFilePath { get; set; }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,6 +22,7 @@ and behavior of Cake.Issues.Recipe.
 | `IssuesParameters.InputFiles.MsBuildBinaryLogFilePath`        | `null`        | Path to the MSBuild binary log file.                   |
 | `IssuesParameters.InputFiles.InspectCodeLogFilePath`          | `null`        | Path to the JetBrains InspectCode log file.            |
 | `IssuesParameters.InputFiles.MarkdownlintCliLogFilePath`      | `null`        | Path to the markdownlint-cli log file.                 |
+| `IssuesParameters.InputFiles.MarkdownlintV1LogFilePath`       | `null`        | Path to the markdownlint log file in version 1.        |
 
 # Report creation
 

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -16,9 +16,11 @@ Cake.Issues.Recipe supports reading issues from output of the following tools:
 | MsBuild                           | Binary Log File                        | `IssuesParameters.InputFiles.MsBuildBinaryLogFilePath`        |
 | JetBrains InspectCode (ReSharper) |                                        | `IssuesParameters.InputFiles.InspectCodeLogFilePath`          |
 | markdownlint                      | [markdownlint-cli]                     | `IssuesParameters.InputFiles.MarkdownlintCliLogFilePath`      |
+| markdownlint                      | [markdownlint] version 1               | `IssuesParameters.InputFiles.MarkdownlintV1LogFilePath`       |
 
 [MSBuild Extension Pack XmlFileLogger]: http://www.msbuildextensionpack.com/help/4.0.5.0/html/242ab4fd-c2e2-f6aa-325b-7588725aed24.htm
 [markdownlint-cli]: https://github.com/igorshubovych/markdownlint-cli
+[markdownlint]: https://github.com/DavidAnson/markdownlint
 
 # Build systems
 


### PR DESCRIPTION
Add support for files generated by markdownlint with `options.resultVersion` set to 1 as input.

Fixes #6