### PR TITLE
Use node.js version 14 on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@
 install:
   # Update to latest NuGet version since we require 5.3.0 for embedded icon
   - ps: nuget update -self
+  - ps: Install-Product node 14
   - ps: choco install markdownlint-cli --no-progress
 
 build_script:


### PR DESCRIPTION
Use node.js version 14 on AppVeyor