### PR TITLE
Use current NuGet package for integration tests on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ build_script:
 
 # Tests
 test_script:
-  - ps: .\tests\integration\build.ps1 -Script .\tests\integration\build.cake
+  - ps: .\tests\integration\build.ps1 -script .\tests\integration\build.cake -verbosity diagnostic
 
 #---------------------------------#
 #        Branches to build        #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,8 @@ build_script:
 
 # Tests
 test_script:
-  - ps: .\tests\integration\build.ps1 -script .\tests\integration\build.cake -verbosity diagnostic
+  - ps: cd .\tests\integration\
+  - ps: .\build.ps1 -verbosity diagnostic
 
 #---------------------------------#
 #        Branches to build        #


### PR DESCRIPTION
Since integration tests on AppVeyor have repo root as working directory it doesn't find the NuGet package created in the build step and instead tests with latest version from nuget.org. This PR fixes this by setting the working directory.