### PR TITLE
Install markdownlint before Node update to avoid permission issues

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,8 @@ image: Visual Studio 2019
 install:
   # Update to latest NuGet version since we require 5.3.0 for embedded icon
   - ps: nuget update -self
-  - ps: Install-Product node 14
   - ps: choco install markdownlint-cli --no-progress
+  - ps: Install-Product node 14
 
 build_script:
   - ps: .\build.ps1 -Target AppVeyor


### PR DESCRIPTION
Install markdownlint before Node update to avoid permission issues and have the build failed due to markdownlint not being found.

This will throw some warnings, but should work.