### PR TITLE
Rename PR parameters in Cake.Issues.FrostingRecipe

### DIFF
--- a/Cake.Issues.FrostingRecipe/Cake.Issues.FrostingRecipe/Context/Parameters/IssuesParameters.cs
+++ b/Cake.Issues.FrostingRecipe/Cake.Issues.FrostingRecipe/Context/Parameters/IssuesParameters.cs
@@ -38,8 +38,8 @@ namespace Cake.Issues.FrostingRecipe
         public IssuesParametersBuildServer BuildServer { get; } = new IssuesParametersBuildServer();
 
         /// <summary>
-        /// Gets the parameters for pull request system integration.
+        /// Gets the parameters for pull request integration.
         /// </summary>
-        public IssuesParametersPullRequestSystem PullRequestSystem { get; } = new IssuesParametersPullRequestSystem();
+        public IssuesParametersPullRequest PullRequest { get; } = new IssuesParametersPullRequest();
     }
 }

--- a/Cake.Issues.FrostingRecipe/Cake.Issues.FrostingRecipe/Context/Parameters/IssuesParametersPullRequest.cs
+++ b/Cake.Issues.FrostingRecipe/Cake.Issues.FrostingRecipe/Context/Parameters/IssuesParametersPullRequest.cs
@@ -3,7 +3,7 @@ namespace Cake.Issues.FrostingRecipe
     /// <summary>
     /// Parameters for pull request integration.
     /// </summary>
-    public class IssuesParametersPullRequestSystem
+    public class IssuesParametersPullRequest
     {
         /// <summary>
         /// Gets or sets a value indicating whether issues should be reported to the pull request system.

--- a/Cake.Issues.FrostingRecipe/Cake.Issues.FrostingRecipe/ReportIssuesToPullRequestTask.cs
+++ b/Cake.Issues.FrostingRecipe/Cake.Issues.FrostingRecipe/ReportIssuesToPullRequestTask.cs
@@ -19,7 +19,7 @@ namespace Cake.Issues.FrostingRecipe
         {
             return
                 !context.BuildSystem().IsLocalBuild &&
-                context.Parameters.PullRequestSystem.ShouldReportIssuesToPullRequest &&
+                context.Parameters.PullRequest.ShouldReportIssuesToPullRequest &&
                 context.State.BuildServer != null && context.State.BuildServer.DetermineIfPullRequest(context);
         }
         #endregion

--- a/Cake.Issues.FrostingRecipe/Cake.Issues.FrostingRecipe/SetPullRequestIssuesStateTask.cs
+++ b/Cake.Issues.FrostingRecipe/Cake.Issues.FrostingRecipe/SetPullRequestIssuesStateTask.cs
@@ -19,7 +19,7 @@ namespace Cake.Issues.FrostingRecipe
         {
             return
                 !context.BuildSystem().IsLocalBuild &&
-                context.Parameters.PullRequestSystem.ShouldReportIssuesToPullRequest &&
+                context.Parameters.PullRequest.ShouldReportIssuesToPullRequest &&
                 context.State.BuildServer != null && context.State.BuildServer.DetermineIfPullRequest(context);
         }
         #endregion


### PR DESCRIPTION
Rename PR parameters in Cake.Issues.FrostingRecipe to be consistent with Cake.Issues.Recipe