### PR TITLE
Add examples from Cake.Issues.Website

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,9 +1,0 @@
----
-Order: 20
-Title: Usage
-Description: How to use Cake.Issues recipes in your build script.
----
-
-Examples how to use Cake.Issues recipes can be found under [usage].
-
-[usage]: ../usage/recipe/

--- a/docs/usage/index.cshtml
+++ b/docs/usage/index.cshtml
@@ -1,0 +1,7 @@
+---
+Order: 20
+Description: How to use Cake.Issues recipes in your build script.
+---
+<p>@Html.Raw(Model.String(DocsKeys.Description))</p>
+
+@Html.Partial("_ChildPages")

--- a/docs/usage/using-cake-frosting-issues-recipe.md
+++ b/docs/usage/using-cake-frosting-issues-recipe.md
@@ -1,0 +1,121 @@
+---
+Order: 20
+Title: Using Cake.Frosting.Issues.Recipe
+Description: Basic usage of Cake.Frosting.Issues.Recipe.
+---
+The [Cake.Frosting.Issues.Recipe] package can be used to easily add issue management functionality to your Cake Frosting build.
+
+# Add Cake.Frosting.Issues.Recipe to your Cake Frosting build
+
+To use [Cake.Frosting.Issues.Recipe] in your Cake Frosting build you need to first add the NuGet package in your `.csproj` file:
+
+```csharp
+<PackageReference Include="Cake.Frosting.Issues.Recipe" Version="1.0.0" />
+```
+
+:::{.alert .alert-warning}
+Replace the version (`1.0.0`) with the version of Cake.Frosting.Issues.Recipe you want to use.
+:::
+
+# Register Cake.Issues tasks
+
+To make Cake Issues tasks available to your Cake Frosting build you need to register them.
+
+Add the following line to the bootstrapping code in the `Main` method of your Cake Frosting project:
+
+```csharp
+AddAssembly(Assembly.GetAssembly(typeof(IssuesTask)))
+```
+
+The following bootstrapping code registers the Cake Issues tasks and also installs JetBrains InspectCode:
+
+```csharp
+using System;
+using System.Reflection;
+using Cake.Frosting;
+using Cake.Frosting.Issues.Recipe;
+
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        return new CakeHost()
+            .UseContext<BuildContext>()
+            .InstallTool(new Uri("nuget:?package=JetBrains.ReSharper.CommandLineTools"))
+            .AddAssembly(Assembly.GetAssembly(typeof(IssuesTask)))
+            .Run(args);
+    }
+}
+```
+
+# Create build context
+
+[Cake.Frosting.Issues.Recipe] provides a build context from which you need to inherit your custom build context.
+The build context contains configuration parameters, but also the state of the current running build,
+like for example all collected issues.
+
+The following example creates a build context and defines that Cake Issues should use Cake.Git addin to determine
+state of the Git repository:
+
+```csharp
+public class BuildContext : IssuesContext
+{
+    public BuildContext(ICakeContext context)
+        : base(context, RepositoryInfoProviderType.CakeGit)
+    {
+    }
+}
+```
+
+# Passing issues to Cake.Frosting.Issues.Recipe
+
+To make issues available to [Cake.Frosting.Issues.Recipe] you need pass the log files through the corresponding methods.
+The tasks need to also be a dependency of `ReadIssuesTask` provided by [Cake.Frosting.Issues.Recipe].
+
+In the following example a new task is introduced which runs JetBrains InspectCode and passes the log file to [Cake.Frosting.Issues.Recipe]:
+
+```csharp
+[TaskName("Run-InspectCode")]
+[IsDependeeOf(typeof(ReadIssuesTask))]
+public class RunInspectCodeTask : FrostingTask<BuildContext>
+{
+    public override void Run(BuildContext context)
+    {
+        var buildArtifactsDirectory = new DirectoryPath("BuildArtifacts");
+        var inspectCodeLogFilePath = buildArtifactsDirectory.CombineWithFilePath("inspectCode.log");
+
+        // Run JetBrains InspectCode
+        context.InspectCode(
+            context.State.BuildRootDirectory.Combine("..").Combine("src").CombineWithFilePath("ClassLibrary1.sln"),
+            new InspectCodeSettings() {
+                OutputFile = context.InspectCodeLogFilePath
+            });
+
+        // Pass path to InspectCode log file to Cake.Frosting.Issues.Recipe
+        context.Parameters.InputFiles.AddInspectCodeLogFile(context.InspectCodeLogFilePath);
+    }
+}
+```
+
+See [configuration] for a full list of available configuration parameters.
+
+# Calling issues tasks
+
+[Cake.Frosting.Issues.Recipe] will add a bunch of [tasks] to your build script.
+
+To add the issues functionality into your existing build pipeline you need to add
+`ReadIssuesTask` to your pipeline.
+
+ In the following example the `Default` task makes sure the main `IssuesTask` is executed:
+
+```csharp
+[TaskName("Default")]
+[IsDependentOn(typeof(IssuesTask))]
+public class DefaultTask : FrostingTask
+{
+}
+```
+
+[Cake.Frosting.Issues.Recipe]: ../../recipe/
+[configuration]: ../../recipe/configuration
+[tasks]: ../../recipe/tasks

--- a/docs/usage/using-cake-issues-recipe.md
+++ b/docs/usage/using-cake-issues-recipe.md
@@ -1,0 +1,68 @@
+---
+Order: 10
+Title: Using Cake.Issues.Recipe
+Description: Basic usage of Cake.Issues.Recipe.
+---
+The [Cake.Issues.Recipe] package can be used to easily add issue management functionality to your build script.
+
+# Add Cake.Issues.Recipe to your build script
+
+To use Cake.Issues.Recipe in your build script you need to first load the NuGet package:
+
+```csharp
+#load nuget:package=Cake.Issues.Recipe
+```
+
+:::{.alert .alert-warning}
+Please note that you always should pin NuGet packages to a specific version to make sure your builds are deterministic and
+won't break due to updates to Cake.Issues.Recipe.
+
+See [pinning addin versions](https://cakebuild.net/docs/tutorials/pinning-cake-version#pinning-addin-version) for details.
+:::
+
+# Configuring Cake.Issues.Recipe
+
+To make issues available to Cake.Issues.Recipe you need to set the corresponding configuration parameters.
+
+In the following example a new task is introduced which depends on existing tasks which build a MsBuild solution and run JetBrains InspectCode.
+It will pass the MsBuild and InspectCode logfile to Cake.Issues.Recipe:
+
+```csharp
+// Run issues task by default.
+Task("Configure-CakeIssuesRecipe")
+    .IsDependentOn("Build")
+    .IsDependentOn("Run-InspectCode")
+    .Does(() =>
+{
+    IssuesParameters.InputFiles.AddMsBuildXmlFileLoggerLogFile(msBuildLogFilePath);
+    IssuesParameters.InputFiles.AddInspectCodeLogFile(inspectCodeLogFilePath);
+}
+```
+
+See [configuration] for a full list of available configuration parameters.
+
+# Calling issues tasks
+
+Cake.Issues.Recipe will add a bunch of [tasks] to your build script.
+
+To add the issues functionality into your existing build pipeline you can make
+the `Read-Issues` task dependent on the task which configures Cake.Issues.Recipe:
+
+```csharp
+// Make sure build and linters run before issues task.
+IssuesBuildTasks.ReadIssuesTask
+    .IsDependentOn("Configure-CakeIssuesRecipe");
+```
+
+At some point you need to call the tasks provided by Cake.Isses.Recipe.
+In the following example the `Default` task calls the main `Issues` task:
+
+```csharp
+// Run issues task by default.
+Task("Default")
+    .IsDependentOn("Issues");
+```
+
+[Cake.Issues.Recipe]: ../../recipe/
+[configuration]: ../../recipe/configuration
+[tasks]: ../../recipe/tasks


### PR DESCRIPTION
Move examples from Cake.Issues.Website to Cake.Issues.Recipe repo.

Also updates examples to Cake.Issues recipes 1.0.

Part of https://github.com/cake-contrib/Cake.Issues.Website/issues/184