### PR TITLE
Make sure to always use latest version in Frosting tests

### DIFF
--- a/tests/frosting/net5.0/build.ps1
+++ b/tests/frosting/net5.0/build.ps1
@@ -1,2 +1,13 @@
+$RECIPE_PACKAGE_PATH = "packages/cake.frosting.issues.recipe"
+if (Test-Path $RECIPE_PACKAGE_PATH)
+{
+    Write-Host "Cleaning up cached version of $RECIPE_PACKAGE_PATH..."
+    Remove-Item $RECIPE_PACKAGE_PATH -Recurse;
+}
+else
+{
+    Write-Host "$RECIPE_PACKAGE_PATH not cached..."
+}
+
 dotnet run --project build/Build.csproj -- $args
 exit $LASTEXITCODE;

--- a/tests/frosting/net5.0/build.sh
+++ b/tests/frosting/net5.0/build.sh
@@ -1,1 +1,11 @@
+
+$RECIPE_PACKAGE_PATH = "packages/cake.frosting.issues.recipe"
+if [ -d "$RECIPE_PACKAGE_PATH" ]
+then
+    echo "Cleaning up cached version of $RECIPE_PACKAGE_PATH..."
+    rm -Rf $RECIPE_PACKAGE_PATH
+else
+    echo "$RECIPE_PACKAGE_PATH not cached..."
+fi
+
 dotnet run --project ./build/Build.csproj -- "$@"


### PR DESCRIPTION
Make sure to always use latest version of Cake.Frosting.Issues.Recipe in Frosting integration tests