### PR TITLE
(GH-233) Use project root directory for creating issue report

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/CreateFullIssuesReportTask.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/CreateFullIssuesReportTask.cs
@@ -40,7 +40,7 @@ namespace Cake.Frosting.Issues.Recipe
             context.CreateIssueReport(
                 context.State.Issues,
                 context.GenericIssueReportFormat(context.Parameters.Reporting.FullIssuesReportSettings),
-                context.State.BuildRootDirectory,
+                context.State.ProjectRootDirectory,
                 context.State.FullIssuesReport);
         }
     }

--- a/Cake.Issues.Recipe/Content/build.cake
+++ b/Cake.Issues.Recipe/Content/build.cake
@@ -150,7 +150,7 @@ IssuesBuildTasks.CreateFullIssuesReportTask = Task("Create-FullIssuesReport")
     CreateIssueReport(
         data.Issues,
         GenericIssueReportFormat(IssuesParameters.Reporting.FullIssuesReportSettings),
-        data.BuildRootDirectory,
+        data.ProjectRootDirectory,
         data.FullIssuesReport);
 });
 


### PR DESCRIPTION
Use project root directory instead of build directory for creating issue report.

Fixes #233