### PR TITLE
(GH-230) Use project root directory for file link settings

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/PullRequestSystems/AzureDevOpsPullRequestSystem.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/PullRequestSystems/AzureDevOpsPullRequestSystem.cs
@@ -87,7 +87,7 @@ namespace Cake.Frosting.Issues.Recipe
         {
             context.NotNull(nameof(context));
 
-            var rootPath = context.State.RepositoryRootDirectory.GetRelativePath(context.State.BuildRootDirectory);
+            var rootPath = context.State.RepositoryRootDirectory.GetRelativePath(context.State.ProjectRootDirectory);
 
             return context.IssueFileLinkSettingsForAzureDevOpsCommit(
                 context.State.RepositoryRemoteUrl,

--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/PullRequestSystems/GitHubPullRequestSystem.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/PullRequestSystems/GitHubPullRequestSystem.cs
@@ -28,7 +28,7 @@ namespace Cake.Frosting.Issues.Recipe
         {
             context.NotNull(nameof(context));
 
-            var rootPath = context.State.RepositoryRootDirectory.GetRelativePath(context.State.BuildRootDirectory);
+            var rootPath = context.State.RepositoryRootDirectory.GetRelativePath(context.State.ProjectRootDirectory);
 
             return context.IssueFileLinkSettingsForGitHubCommit(
                 context.State.RepositoryRemoteUrl,

--- a/Cake.Issues.Recipe/Content/tasks/pullrequestsystems/AzureDevOpsPullRequestSystem.cake
+++ b/Cake.Issues.Recipe/Content/tasks/pullrequestsystems/AzureDevOpsPullRequestSystem.cake
@@ -71,7 +71,7 @@ public class AzureDevOpsPullRequestSystem : BasePullRequestSystem
         context.NotNull(nameof(context));
         data.NotNull(nameof(data));
 
-        var rootPath = data.RepositoryRootDirectory.GetRelativePath(data.BuildRootDirectory);
+        var rootPath = data.RepositoryRootDirectory.GetRelativePath(data.ProjectRootDirectory);
 
         return context.IssueFileLinkSettingsForAzureDevOpsCommit(
             data.RepositoryRemoteUrl,

--- a/Cake.Issues.Recipe/Content/tasks/pullrequestsystems/GitHubPullRequestSystem.cake
+++ b/Cake.Issues.Recipe/Content/tasks/pullrequestsystems/GitHubPullRequestSystem.cake
@@ -27,7 +27,7 @@ public class GitHubPullRequestSystem : BasePullRequestSystem
         context.NotNull(nameof(context));
         data.NotNull(nameof(data));
 
-        var rootPath = data.RepositoryRootDirectory.GetRelativePath(data.BuildRootDirectory);
+        var rootPath = data.RepositoryRootDirectory.GetRelativePath(data.ProjectRootDirectory);
 
         return context.IssueFileLinkSettingsForGitHubCommit(
             data.RepositoryRemoteUrl,


### PR DESCRIPTION
Use project root directory for file link settings

Part of #230 