### PR TITLE
(GH-231) Use project root directory for reporting issues to pull request systems

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/AppVeyorBuildServer.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/AppVeyorBuildServer.cs
@@ -65,7 +65,7 @@ namespace Cake.Frosting.Issues.Recipe
             context.ReportIssuesToPullRequest(
                 context.State.Issues,
                 context.AppVeyorBuilds(),
-                context.State.BuildRootDirectory);
+                context.State.ProjectRootDirectory);
         }
 
         /// <inheritdoc />

--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/GitHubActionsBuildServer.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/GitHubActionsBuildServer.cs
@@ -58,7 +58,7 @@ namespace Cake.Frosting.Issues.Recipe
             context.ReportIssuesToPullRequest(
                 context.State.Issues,
                 context.GitHubActionsBuilds(),
-                context.State.BuildRootDirectory);
+                context.State.ProjectRootDirectory);
         }
 
         /// <inheritdoc />

--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/PullRequestSystems/AzureDevOpsPullRequestSystem.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/PullRequestSystems/AzureDevOpsPullRequestSystem.cs
@@ -34,7 +34,7 @@ namespace Cake.Frosting.Issues.Recipe
                     context.State.BuildServer.DetermineRepositoryRemoteUrl(context, context.State.RepositoryRootDirectory),
                     context.State.BuildServer.DeterminePullRequestId(context).Value,
                     context.AzureDevOpsAuthenticationOAuth(context.EnvironmentVariable("SYSTEM_ACCESSTOKEN"))),
-                context.State.BuildRootDirectory);
+                context.State.ProjectRootDirectory);
             #endregion
         }
 

--- a/Cake.Issues.Recipe/Content/tasks/buildservers/AppVeyorBuildServer.cake
+++ b/Cake.Issues.Recipe/Content/tasks/buildservers/AppVeyorBuildServer.cake
@@ -57,7 +57,7 @@ public class AppVeyorBuildServer : BaseBuildServer
         context.ReportIssuesToPullRequest(
             data.Issues,
             context.AppVeyorBuilds(),
-            data.BuildRootDirectory);
+            data.ProjectRootDirectory);
     }
 
     /// <inheritdoc />

--- a/Cake.Issues.Recipe/Content/tasks/buildservers/GitHubActionsBuildServer.cake
+++ b/Cake.Issues.Recipe/Content/tasks/buildservers/GitHubActionsBuildServer.cake
@@ -51,7 +51,7 @@ public class GitHubActionsBuildServer : BaseBuildServer
         context.ReportIssuesToPullRequest(
             data.Issues,
             context.GitHubActionsBuilds(),
-            data.BuildRootDirectory);
+            data.ProjectRootDirectory);
     }
 
     /// <inheritdoc />

--- a/Cake.Issues.Recipe/Content/tasks/pullrequestsystems/AzureDevOpsPullRequestSystem.cake
+++ b/Cake.Issues.Recipe/Content/tasks/pullrequestsystems/AzureDevOpsPullRequestSystem.cake
@@ -21,7 +21,7 @@ public class AzureDevOpsPullRequestSystem : BasePullRequestSystem
                 data.BuildServer.DetermineRepositoryRemoteUrl(context, data.RepositoryRootDirectory),
                 data.BuildServer.DeterminePullRequestId(context).Value,
                 context.AzureDevOpsAuthenticationOAuth(context.EnvironmentVariable("SYSTEM_ACCESSTOKEN"))),
-            data.BuildRootDirectory);
+            data.ProjectRootDirectory);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Use project root directory instead of build directory for reporting issues to pull request systems.

Fixes #231 