### PR TITLE
Update Cake.Recipe to 2.2.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,12 +171,12 @@ jobs:
   - publish: $(Build.SourcesDirectory)/tests/script-runner/BuildArtifacts/output
     artifact: Integration Tests Script Runner macOS 10.15 (.NET Core tool)
     displayName: 'Publish generated reports as build artifact'
-# Integration Tests Script Runner Ubuntu 16.04 (Mono)
+# Integration Tests Script Runner Ubuntu 18.04 (Mono)
 - job: Test_Script_Runner_ubuntu_Mono
-  displayName: 'Integration Tests Script Runner Ubuntu 16.04 (Mono)'
+  displayName: 'Integration Tests Script Runner Ubuntu 18.04 (Mono)'
   dependsOn: Build
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
   - task: NodeTool@0
     inputs:
@@ -198,14 +198,14 @@ jobs:
     workingDirectory: ./tests/script-runner/
     displayName: 'Run integration tests'
   - publish: $(Build.SourcesDirectory)/tests/script-runner/BuildArtifacts/output
-    artifact: Integration Tests Script Runner Ubuntu 16.04 (Mono)
+    artifact: Integration Tests Script Runner Ubuntu 18.04 (Mono)
     displayName: 'Publish generated reports as build artifact'
-# Integration Tests Script Runner Ubuntu 16.04 (.NET Core tool)
+# Integration Tests Script Runner Ubuntu 18.04 (.NET Core tool)
 - job: Test_Script_Runner_ubuntu_DotNetCoreTool
-  displayName: Integration Tests Script Runner Ubuntu 16.04 (.NET Core tool)
+  displayName: Integration Tests Script Runner Ubuntu 18.04 (.NET Core tool)
   dependsOn: Build
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   steps:
   - task: NodeTool@0
     inputs:
@@ -231,5 +231,5 @@ jobs:
     workingDirectory: ./tests/script-runner/
     displayName: 'Run integration tests'
   - publish: $(Build.SourcesDirectory)/tests/script-runner/BuildArtifacts/output
-    artifact: Integration Tests Script Runner Ubuntu 16.04 (.NET Core tool)
+    artifact: Integration Tests Script Runner Ubuntu 18.04 (.NET Core tool)
     displayName: 'Publish generated reports as build artifact'

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Cake.Recipe&version=2.1.0
+#load nuget:?package=Cake.Recipe&version=2.2.1
 
 Environment.SetVariableNames();
 

--- a/tests/script-runner/build.cake
+++ b/tests/script-runner/build.cake
@@ -3,8 +3,8 @@
 
 #addin "Cake.Markdownlint"
 
-#tool "nuget:?package=JetBrains.ReSharper.CommandLineTools"
-#tool "nuget:?package=MSBuild.Extension.Pack"
+#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2021.2.2
+#tool nuget:?package=MSBuild.Extension.Pack&version=1.9.1
 
 //////////////////////////////////////////////////
 // ARGUMENTS
@@ -86,7 +86,8 @@ Task("Run-InspectCode")
     .Does<BuildData>((data) =>
 {
     var settings = new InspectCodeSettings() {
-        OutputFile = data.InspectCodeLogFilePath
+        OutputFile = data.InspectCodeLogFilePath,
+        ArgumentCustomization = x => x.Append("--no-build")
     };
 
     InspectCode(


### PR DESCRIPTION
Updates Cake.Recipe to 2.2.1, runs Linux tests on Ubuntu 18.04 and fixes JetBrains tools version.