### PR TITLE
Change Cake.AzureDevOps from 1.1 to 1.0

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
@@ -36,7 +36,7 @@ For recipe compatible with Cake Script Runners see Cake.Issues.Recipe.</Descript
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.AzureDevOps" Version="1.1.0" />
+    <PackageReference Include="Cake.AzureDevOps" Version="1.0.0" />
     <PackageReference Include="Cake.Frosting" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Git" Version="1.1.0" />
     <PackageReference Include="Cake.Issues" Version="1.0.0" />

--- a/Cake.Issues.Recipe/Content/addins.cake
+++ b/Cake.Issues.Recipe/Content/addins.cake
@@ -15,4 +15,4 @@
 #addin nuget:?package=Cake.Issues.PullRequests.AppVeyor&version=1.0.0
 #addin nuget:?package=Cake.Issues.PullRequests.AzureDevOps&version=1.0.0
 #addin nuget:?package=Cake.Issues.PullRequests.GitHubActions&version=1.0.0
-#addin nuget:?package=Cake.AzureDevOps&version=1.1.0
+#addin nuget:?package=Cake.AzureDevOps&version=1.0.0


### PR DESCRIPTION
Since Cake.AzureDevOps 1.1 introduces a breaking change we need to revert back to 1.0

Reverts #246
Fixes #258 