### PR TITLE
(GH-262) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Frosting.Issues.Recipe.xml</DocumentationFile>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>


### PR DESCRIPTION
Multi-Target Frosting Recipe to .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #262