### PR TITLE
(GH-281) Use ShouldSetPullRequestStatus to control setting of pull request state

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/SetPullRequestIssuesStateTask.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/SetPullRequestIssuesStateTask.cs
@@ -21,7 +21,7 @@ namespace Cake.Frosting.Issues.Recipe
 
             return
                 !context.BuildSystem().IsLocalBuild &&
-                context.Parameters.PullRequestSystem.ShouldReportIssuesToPullRequest &&
+                context.Parameters.PullRequestSystem.ShouldSetPullRequestStatus &&
                 context.State.BuildServer != null && context.State.BuildServer.DetermineIfPullRequest(context);
         }
         #endregion


### PR DESCRIPTION
Use `ShouldSetPullRequestStatus` instead of `ShouldReportIssuesToPullRequest` to control setting of pull request state.