### PR TITLE
Test against Ubuntu 22.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -244,35 +244,6 @@ jobs:
   - publish: $(Build.SourcesDirectory)/tests/script-runner/BuildArtifacts/output
     artifact: Integration Tests Script Runner macOS 12 (.NET Core tool)
     displayName: 'Publish generated reports as build artifact'
-# Integration Tests Frosting Ubuntu 18.04 (.NET 5)
-- job: Test_Frosting_ubuntu_1804_Net5
-  displayName: Integration Tests Frosting Ubuntu 18.04 (.NET 5)
-  dependsOn: Build
-  pool:
-    vmImage: 'ubuntu-18.04'
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '14.x'
-    displayName: 'Install NodeJs 14.x'
-  - bash: |
-      npm install -g markdownlint-cli
-    displayName: 'Install required tools'
-  - download: current
-    artifact: NuGet Package
-    displayName: 'Download build artifact'
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: $(Pipeline.Workspace)/NuGet Package
-      targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
-    displayName: 'Copy build artifact for test run'
-  - bash: |
-      ./build.sh --verbosity=diagnostic
-    workingDirectory: ./tests/frosting/net5.0
-    displayName: 'Run integration tests'
-  - publish: $(Build.SourcesDirectory)/tests/frosting/net5.0/build/BuildArtifacts/output
-    artifact: Integration Tests Frosting Ubuntu 18.04 (.NET 5)
-    displayName: 'Publish generated reports as build artifact'
 # Integration Tests Frosting Ubuntu 20.04 (.NET 6)
 - job: Test_Frosting_ubuntu_2004_Net6
   displayName: Integration Tests Frosting Ubuntu 20.04 (.NET 6)
@@ -302,12 +273,12 @@ jobs:
   - publish: $(Build.SourcesDirectory)/tests/frosting/net6.0/build/BuildArtifacts/output
     artifact: Integration Tests Frosting Ubuntu 20.04 (.NET 6)
     displayName: 'Publish generated reports as build artifact'
-# Integration Tests Script Runner Ubuntu 18.04 (.NET Core tool)
-- job: Test_Script_Runner_ubuntu_1804_DotNetCoreTool
-  displayName: Integration Tests Script Runner Ubuntu 18.04 (.NET Core tool)
+# Integration Tests Frosting Ubuntu 22.04 (.NET 6)
+- job: Test_Frosting_ubuntu_2204_Net6
+  displayName: Integration Tests Frosting Ubuntu 22.04 (.NET 6)
   dependsOn: Build
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-22.04'
   steps:
   - task: NodeTool@0
     inputs:
@@ -326,10 +297,10 @@ jobs:
     displayName: 'Copy build artifact for test run'
   - bash: |
       ./build.sh --verbosity=diagnostic
-    workingDirectory: ./tests/script-runner/
+    workingDirectory: ./tests/frosting/net6.0
     displayName: 'Run integration tests'
-  - publish: $(Build.SourcesDirectory)/tests/script-runner/BuildArtifacts/output
-    artifact: Integration Tests Script Runner Ubuntu 18.04 (.NET Core tool)
+  - publish: $(Build.SourcesDirectory)/tests/frosting/net6.0/build/BuildArtifacts/output
+    artifact: Integration Tests Frosting Ubuntu 22.04 (.NET 6)
     displayName: 'Publish generated reports as build artifact'
 # Integration Tests Script Runner Ubuntu 20.04 (.NET Core tool)
 - job: Test_Script_Runner_ubuntu_2004_DotNetCoreTool
@@ -359,4 +330,33 @@ jobs:
     displayName: 'Run integration tests'
   - publish: $(Build.SourcesDirectory)/tests/script-runner/BuildArtifacts/output
     artifact: Integration Tests Script Runner Ubuntu 20.04 (.NET Core tool)
+    displayName: 'Publish generated reports as build artifact'
+# Integration Tests Script Runner Ubuntu 22.04 (.NET Core tool)
+- job: Test_Script_Runner_ubuntu_2204_DotNetCoreTool
+  displayName: Integration Tests Script Runner Ubuntu 22.04 (.NET Core tool)
+  dependsOn: Build
+  pool:
+    vmImage: 'ubuntu-22.04'
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '14.x'
+    displayName: 'Install NodeJs 14.x'
+  - bash: |
+      npm install -g markdownlint-cli
+    displayName: 'Install required tools'
+  - download: current
+    artifact: NuGet Package
+    displayName: 'Download build artifact'
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/NuGet Package
+      targetFolder: $(Build.SourcesDirectory)/BuildArtifacts/Packages/NuGet
+    displayName: 'Copy build artifact for test run'
+  - bash: |
+      ./build.sh --verbosity=diagnostic
+    workingDirectory: ./tests/script-runner/
+    displayName: 'Run integration tests'
+  - publish: $(Build.SourcesDirectory)/tests/script-runner/BuildArtifacts/output
+    artifact: Integration Tests Script Runner Ubuntu 22.04 (.NET Core tool)
     displayName: 'Publish generated reports as build artifact'


### PR DESCRIPTION
Remove testing on deprecated Ubuntu 18.04 image on Azure Pipelines and test on Ubuntu 22.04 instead.