### PR TITLE
(GH-289) Use Cake.Git when RepositoryInfoProviderType.CakeGit is configured

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Context/State/IssuesState.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Context/State/IssuesState.cs
@@ -133,7 +133,7 @@ namespace Cake.Frosting.Issues.Recipe
             {
                 case RepositoryInfoProviderType.CakeGit:
                     context.Information("Using Cake.Git for providing repository information");
-                    return new CliRepositoryInfoProvider();
+                    return new CakeGitRepositoryInfoProvider();
                 case RepositoryInfoProviderType.Cli:
                     context.Information("Using Git CLI for providing repository information");
                     return new CliRepositoryInfoProvider();

--- a/Cake.Issues.Recipe/Content/data/IssuesData.cake
+++ b/Cake.Issues.Recipe/Content/data/IssuesData.cake
@@ -147,7 +147,7 @@ public class IssuesData
         {
             case RepositoryInfoProviderType.CakeGit:
                 context.Information("Using Cake.Git for providing repository information");
-                return new CliRepositoryInfoProvider();
+                return new CakeGitRepositoryInfoProvider();
             case RepositoryInfoProviderType.Cli:
                 context.Information("Using Git CLI for providing repository information");
                 return new CliRepositoryInfoProvider();


### PR DESCRIPTION
Fixes bug where Git CLI instead of Cake.Git is used when `RepositoryInfoProviderType.CakeGit` is configured

Fixes #289 