### PR TITLE
(GH-301) Make FullIssuesReportSettings writable

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Context/Parameters/IIssuesParametersReporting.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Context/Parameters/IIssuesParametersReporting.cs
@@ -14,10 +14,10 @@ namespace Cake.Frosting.Issues.Recipe
         bool ShouldCreateFullIssuesReport { get; set; }
 
         /// <summary>
-        /// Gets the settings for the full issues report.
+        /// Gets or sets the settings for the full issues report.
         /// By default <see cref="GenericIssueReportTemplate.HtmlDxDataGrid"/> template is used
         /// with <see cref="DevExtremeTheme.MaterialBlueLight"/> theme.
         /// </summary>
-        GenericIssueReportFormatSettings FullIssuesReportSettings { get; }
+        GenericIssueReportFormatSettings FullIssuesReportSettings { get; set; }
     }
 }

--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Context/Parameters/IssuesParametersReporting.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Context/Parameters/IssuesParametersReporting.cs
@@ -11,7 +11,7 @@ namespace Cake.Frosting.Issues.Recipe
         public bool ShouldCreateFullIssuesReport { get; set; } = true;
 
         /// <inheritdoc />
-        public GenericIssueReportFormatSettings FullIssuesReportSettings { get; } =
+        public GenericIssueReportFormatSettings FullIssuesReportSettings { get; set; } =
             GenericIssueReportFormatSettings
                 .FromEmbeddedTemplate(GenericIssueReportTemplate.HtmlDxDataGrid)
                 .WithOption(HtmlDxDataGridOption.Theme, DevExtremeTheme.MaterialBlueLight);

--- a/Cake.Issues.Recipe/Content/parameters/IssuesParametersReporting.cake
+++ b/Cake.Issues.Recipe/Content/parameters/IssuesParametersReporting.cake
@@ -10,11 +10,11 @@ public class IssuesParametersReporting
     public bool ShouldCreateFullIssuesReport { get; set; } = true;
 
     /// <summary>
-    /// Gets the settings for the full issues report.
+    /// Gets or sets the settings for the full issues report.
     /// By default <see cref="GenericIssueReportTemplate.HtmlDxDataGrid"/> template is used
     /// with <see cref="DevExtremeTheme.MaterialBlueLight"/> theme.
     /// </summary>
-    public GenericIssueReportFormatSettings FullIssuesReportSettings { get; } =
+    public GenericIssueReportFormatSettings FullIssuesReportSettings { get; set; } =
         GenericIssueReportFormatSettings
             .FromEmbeddedTemplate(GenericIssueReportTemplate.HtmlDxDataGrid)
             .WithOption(HtmlDxDataGridOption.Theme, DevExtremeTheme.MaterialBlueLight);


### PR DESCRIPTION
Makes `FullIssuesReportSettings` writable to allow creating settings object for a different template.

Fixes #301 