### PR TITLE
Increase allowed number of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   directory: "/Cake.Frosting.Issues.Recipe"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20
   ignore:
   - dependency-name: Cake.Frosting
     versions:


### PR DESCRIPTION
Increase allowed number of Dependabot PRs, since during a release branch number of updated addins can be more than 10