### PR TITLE
Build against Cake 3.0

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
@@ -36,7 +36,7 @@ For recipe compatible with Cake Script Runners see Cake.Issues.Recipe.</Descript
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.AzureDevOps" Version="2.1.1" />
+    <PackageReference Include="Cake.AzureDevOps" Version="3.0.0" />
     <PackageReference Include="Cake.Frosting" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Git" Version="3.0.0" />
     <PackageReference Include="Cake.Issues" Version="2.0.0" />

--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
@@ -39,18 +39,18 @@ For recipe compatible with Cake Script Runners see Cake.Issues.Recipe.</Descript
     <PackageReference Include="Cake.AzureDevOps" Version="3.0.0" />
     <PackageReference Include="Cake.Frosting" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Git" Version="3.0.0" />
-    <PackageReference Include="Cake.Issues" Version="2.0.0" />
+    <PackageReference Include="Cake.Issues" Version="3.0.0-beta0002" />
     <PackageReference Include="Cake.Issues.DupFinder" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.EsLint" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.InspectCode" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.Markdownlint" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.MsBuild" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.PullRequests" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.PullRequests.AppVeyor" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.PullRequests.AzureDevOps" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.PullRequests.GitHubActions" Version="2.0.0" />
-    <PackageReference Include="Cake.Issues.Reporting" Version="2.0.0" />
-    <PackageReference Include="Cake.Frosting.Issues.Reporting.Generic" Version="2.0.1" />
+    <PackageReference Include="Cake.Issues.EsLint" Version="3.0.0-beta0001" />
+    <PackageReference Include="Cake.Issues.InspectCode" Version="3.0.0-beta0001" />
+    <PackageReference Include="Cake.Issues.Markdownlint" Version="3.0.0-beta0001" />
+    <PackageReference Include="Cake.Issues.MsBuild" Version="3.0.0-beta0001" />
+    <PackageReference Include="Cake.Issues.PullRequests" Version="3.0.0-beta0002" />
+    <PackageReference Include="Cake.Issues.PullRequests.AppVeyor" Version="3.0.0-beta0001" />
+    <PackageReference Include="Cake.Issues.PullRequests.AzureDevOps" Version="3.0.0-beta0001" />
+    <PackageReference Include="Cake.Issues.PullRequests.GitHubActions" Version="3.0.0-beta0001" />
+    <PackageReference Include="Cake.Issues.Reporting" Version="3.0.0-beta0002" />
+    <PackageReference Include="Cake.Frosting.Issues.Reporting.Generic" Version="3.0.0-beta0001" />
   </ItemGroup>
 
 </Project>

--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.csproj
@@ -37,7 +37,7 @@ For recipe compatible with Cake Script Runners see Cake.Issues.Recipe.</Descript
 
   <ItemGroup>
     <PackageReference Include="Cake.AzureDevOps" Version="3.0.0" />
-    <PackageReference Include="Cake.Frosting" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Frosting" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Cake.Git" Version="3.0.0" />
     <PackageReference Include="Cake.Issues" Version="2.0.0" />
     <PackageReference Include="Cake.Issues.DupFinder" Version="2.0.0" />

--- a/Cake.Issues.Recipe/Content/addins.cake
+++ b/Cake.Issues.Recipe/Content/addins.cake
@@ -2,7 +2,7 @@
 // ADDINS
 ///////////////////////////////////////////////////////////////////////////////
 
-#addin nuget:?package=Cake.Git&version=2.0.0
+#addin nuget:?package=Cake.Git&version=3.0.0
 #addin nuget:?package=Cake.Issues&version=2.0.0
 #addin nuget:?package=Cake.Issues.MsBuild&version=2.0.0
 #addin nuget:?package=Cake.Issues.InspectCode&version=2.0.0

--- a/Cake.Issues.Recipe/Content/addins.cake
+++ b/Cake.Issues.Recipe/Content/addins.cake
@@ -3,16 +3,16 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #addin nuget:?package=Cake.Git&version=3.0.0
-#addin nuget:?package=Cake.Issues&version=2.0.0
-#addin nuget:?package=Cake.Issues.MsBuild&version=2.0.0
-#addin nuget:?package=Cake.Issues.InspectCode&version=2.0.0
+#addin nuget:?package=Cake.Issues&version=3.0.0-beta0002
+#addin nuget:?package=Cake.Issues.MsBuild&version=3.0.0-beta0001
+#addin nuget:?package=Cake.Issues.InspectCode&version=3.0.0-beta0001
 #addin nuget:?package=Cake.Issues.DupFinder&version=2.0.0
-#addin nuget:?package=Cake.Issues.Markdownlint&version=2.0.0
-#addin nuget:?package=Cake.Issues.EsLint&version=2.0.0
-#addin nuget:?package=Cake.Issues.Reporting&version=2.0.0
-#addin nuget:?package=Cake.Issues.Reporting.Generic&version=2.0.0
-#addin nuget:?package=Cake.Issues.PullRequests&version=2.0.0
-#addin nuget:?package=Cake.Issues.PullRequests.AppVeyor&version=2.0.0
-#addin nuget:?package=Cake.Issues.PullRequests.AzureDevOps&version=2.0.0
-#addin nuget:?package=Cake.Issues.PullRequests.GitHubActions&version=2.0.0
+#addin nuget:?package=Cake.Issues.Markdownlint&version=3.0.0-beta0001
+#addin nuget:?package=Cake.Issues.EsLint&version=3.0.0-beta0001
+#addin nuget:?package=Cake.Issues.Reporting&version=3.0.0-beta0002
+#addin nuget:?package=Cake.Issues.Reporting.Generic&version=3.0.0-beta0001
+#addin nuget:?package=Cake.Issues.PullRequests&version=3.0.0-beta0002
+#addin nuget:?package=Cake.Issues.PullRequests.AppVeyor&version=3.0.0-beta0001
+#addin nuget:?package=Cake.Issues.PullRequests.AzureDevOps&version=3.0.0-beta0001
+#addin nuget:?package=Cake.Issues.PullRequests.GitHubActions&version=3.0.0-beta0001
 #addin nuget:?package=Cake.AzureDevOps&version=3.0.0

--- a/Cake.Issues.Recipe/Content/addins.cake
+++ b/Cake.Issues.Recipe/Content/addins.cake
@@ -15,4 +15,4 @@
 #addin nuget:?package=Cake.Issues.PullRequests.AppVeyor&version=2.0.0
 #addin nuget:?package=Cake.Issues.PullRequests.AzureDevOps&version=2.0.0
 #addin nuget:?package=Cake.Issues.PullRequests.GitHubActions&version=2.0.0
-#addin nuget:?package=Cake.AzureDevOps&version=2.1.1
+#addin nuget:?package=Cake.AzureDevOps&version=3.0.0

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -24,7 +24,7 @@ Cake.Issues recipes will add the following addins to your build:
 
 | Addin Cake.Issues.Recipe                       | Addin.Frosting.Issues.Recipe                   | Remarks |
 |------------------------------------------------|------------------------------------------------|-|
-| [Cake.Git] 2.0.0                               | [Cake.Git] 2.0.0                               | Only used if `RepositoryInfoProvider` type is set to `RepositoryInfoProviderType.CakeGit`. See [Git repository information configuration] for details. |
+| [Cake.Git] 3.0.0                               | [Cake.Git] 3.0.0                               | Only used if `RepositoryInfoProvider` type is set to `RepositoryInfoProviderType.CakeGit`. See [Git repository information configuration] for details. |
 | [Cake.Issues] 2.0.0                            | [Cake.Issues] 2.0.0                            | |
 | [Cake.Issues.MsBuild] 2.0.0                    | [Cake.Issues.MsBuild] 2.0.0                    | |
 | [Cake.Issues.InspectCode] 2.0.0                | [Cake.Issues.InspectCode] 2.0.0                | |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,7 +37,7 @@ Cake.Issues recipes will add the following addins to your build:
 | [Cake.Issues.PullRequests.AppVeyor] 2.0.0      | [Cake.Issues.PullRequests.AppVeyor] 2.0.0      | |
 | [Cake.Issues.PullRequests.AzureDevOps] 2.0.0   | [Cake.Issues.PullRequests.AzureDevOps] 2.0.0   | |
 | [Cake.Issues.PullRequests.GitHubActions] 2.0.0 | [Cake.Issues.PullRequests.GitHubActions] 2.0.0 | |
-| [Cake.AzureDevOps] 2.1.1                       | [Cake.AzureDevOps] 2.1.1                       | |
+| [Cake.AzureDevOps] 3.0.0                       | [Cake.AzureDevOps] 3.0.0                       | |
 
 [Cake.Issues.Recipe]: https://www.nuget.org/packages/Cake.Issues.Recipe
 [Cake.Frosting.Issues.Recipe]: https://www.nuget.org/packages/Cake.Frosting.Issues.Recipe

--- a/recipe.cake
+++ b/recipe.cake
@@ -31,7 +31,7 @@ Task("Generate-Version-File")
         // Write metadata to configuration file
         System.IO.File.WriteAllText(
             "./Cake.Issues.Recipe/cake-version.yml",
-            @"TargetCakeVersion: 2.0.0
+            @"TargetCakeVersion: 3.0.0
 TargetFrameworks:
 - net6.0
 - net7.0"

--- a/tests/frosting/net6.0/build/Build.csproj
+++ b/tests/frosting/net6.0/build/Build.csproj
@@ -5,7 +5,7 @@
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="2.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
     <PackageReference Include="Cake.Frosting.Issues.Recipe" Version="*-*" />
   </ItemGroup>
 </Project>

--- a/tests/frosting/net6.0/build/Program.cs
+++ b/tests/frosting/net6.0/build/Program.cs
@@ -67,7 +67,7 @@ public class BuildState : IssuesState
 
 public class Lifetime : FrostingLifetime<BuildContext>
 {
-    public override void Setup(BuildContext context)
+    public override void Setup(BuildContext context, ISetupContext info)
     {
         // Determine Build Identifier
         var platform = context.Environment.Platform.Family.ToString();

--- a/tests/frosting/net7.0/build/Build.csproj
+++ b/tests/frosting/net7.0/build/Build.csproj
@@ -5,7 +5,7 @@
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" Version="2.0.0" />
+    <PackageReference Include="Cake.Frosting" Version="3.0.0" />
     <PackageReference Include="Cake.Frosting.Issues.Recipe" Version="*-*" />
   </ItemGroup>
 </Project>

--- a/tests/frosting/net7.0/build/Program.cs
+++ b/tests/frosting/net7.0/build/Program.cs
@@ -67,7 +67,7 @@ public class BuildState : IssuesState
 
 public class Lifetime : FrostingLifetime<BuildContext>
 {
-    public override void Setup(BuildContext context)
+    public override void Setup(BuildContext context, ISetupContext info)
     {
         // Determine Build Identifier
         var platform = context.Environment.Platform.Family.ToString();

--- a/tests/script-runner/.config/dotnet-tools.json
+++ b/tests/script-runner/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/tests/script-runner/build.cake
+++ b/tests/script-runner/build.cake
@@ -47,10 +47,10 @@ Task("Build")
             .CombineWithFilePath("ClassLibrary1.sln");
 
 #if NETCOREAPP
-    DotNetCoreRestore(solutionFile.FullPath);
+    DotNetRestore(solutionFile.FullPath);
 
     var settings =
-        new DotNetCoreMSBuildSettings()
+        new DotNetMSBuildSettings()
             .WithTarget("Rebuild")
             .WithLogger(
                 "BinaryLogger," + Context.Tools.Resolve("Cake.Issues.MsBuild*/**/StructuredLogger.dll"),
@@ -58,9 +58,9 @@ Task("Build")
                 data.MsBuildLogFilePath.FullPath
             );
 
-    DotNetCoreBuild(
+    DotNetBuild(
         solutionFile.FullPath,
-        new DotNetCoreBuildSettings
+        new DotNetBuildSettings
         {
             MSBuildSettings = settings
         });

--- a/tests/script-runner/tools/packages.config
+++ b/tests/script-runner/tools/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-    <package id="Cake" version="1.0.0" />
-</packages>


### PR DESCRIPTION
Builds against Cake 3.0.

Also updates the following addins:

- Cake.Git to 3.0
- Cake.AzureDevOps to 3.0
- Cake.Issues to 3.0 Beta

Fixes #330 