### PR TITLE
(GH-374) Publish SARIF report to separate folder on Azure Pipelines

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/AzureDevOpsBuildServer.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/AzureDevOpsBuildServer.cs
@@ -131,7 +131,7 @@ namespace Cake.Frosting.Issues.Recipe
                 context.State.SarifReport != null &&
                 context.FileExists(context.State.SarifReport))
             {
-                context.AzurePipelines().Commands.UploadArtifact("Issues", context.State.SarifReport, "CodeAnalysisLogs");
+                context.AzurePipelines().Commands.UploadArtifact("CodeAnalysisLogs", context.State.SarifReport, "CodeAnalysisLogs");
             }
 
         }

--- a/Cake.Issues.Recipe/Content/tasks/buildservers/AzureDevOpsBuildServer.cake
+++ b/Cake.Issues.Recipe/Content/tasks/buildservers/AzureDevOpsBuildServer.cake
@@ -112,7 +112,7 @@ public class AzureDevOpsBuildServer : BaseBuildServer
             data.SarifReport != null &&
             context.FileExists(data.SarifReport))
         {
-            context.AzurePipelines().Commands.UploadArtifact("Issues", data.SarifReport, "CodeAnalysisLogs");
+            context.AzurePipelines().Commands.UploadArtifact("CodeAnalysisLogs", data.SarifReport, "CodeAnalysisLogs");
         }
     }
 }


### PR DESCRIPTION
Publish SARIF report to separate folder on Azure Pipelines, to avoid having files linked twice on the build

Fixes #374 