### PR TITLE
(GH-462) Fix setting of ProviderIssueLimits and IssueFilters

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Context/Parameters/IssuesParametersPullRequestSystem.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/Context/Parameters/IssuesParametersPullRequestSystem.cs
@@ -24,9 +24,9 @@ namespace Cake.Frosting.Issues.Recipe
         public int? MaxIssuesToPostForEachIssueProvider { get; set; } = 100;
 
         /// <inheritdoc />
-        public Dictionary<string, IProviderIssueLimits> ProviderIssueLimits => new();
+        public Dictionary<string, IProviderIssueLimits> ProviderIssueLimits { get; } = [];
 
         /// <inheritdoc />
-        public IList<Func<IEnumerable<IIssue>, IEnumerable<IIssue>>> IssueFilters => [];
+        public IList<Func<IEnumerable<IIssue>, IEnumerable<IIssue>>> IssueFilters { get; } = [];
     }
 }


### PR DESCRIPTION
Makes `ProviderIssueLimits` and `IssueFilters` a proper initialized property

Fixes #462 