### PR TITLE
Use commit ID from build state

### DIFF
--- a/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/GitHubActionsBuildServer.cs
+++ b/Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe/BuildServers/GitHubActionsBuildServer.cs
@@ -99,7 +99,6 @@ internal sealed class GitHubActionsBuildServer : BaseBuildServer
             return;
         }
 
-        var commitSha = context.GitHubActions().Environment.Workflow.Sha;
         var ref_ = context.GitHubActions().Environment.Workflow.Ref;
 
         // Read and encode SARIF file
@@ -110,7 +109,7 @@ internal sealed class GitHubActionsBuildServer : BaseBuildServer
         var apiUrl = new Uri($"https://api.github.com/repos/{repository}/code-scanning/sarifs");
         var requestBody = new
         {
-            commit_sha = commitSha,
+            commit_sha = context.State.CommitId,
             ref_,
             sarif = sarifBase64,
             tool_name = "Cake.Issues.Recipe"

--- a/Cake.Issues.Recipe/Content/tasks/buildservers/GitHubActionsBuildServer.cake
+++ b/Cake.Issues.Recipe/Content/tasks/buildservers/GitHubActionsBuildServer.cake
@@ -98,7 +98,6 @@ public class GitHubActionsBuildServer : BaseBuildServer
             return;
         }
 
-        var commitSha = context.GitHubActions().Environment.Workflow.Sha;
         var ref_ = context.GitHubActions().Environment.Workflow.Ref;
 
         // Read and encode SARIF file
@@ -109,7 +108,7 @@ public class GitHubActionsBuildServer : BaseBuildServer
         var apiUrl = new System.Uri($"https://api.github.com/repos/{repository}/code-scanning/sarifs");
         var requestBody = new
         {
-            commit_sha = commitSha,
+            commit_sha = data.CommitId,
             ref_,
             sarif = sarifBase64,
             tool_name = "Cake.Issues.Recipe"


### PR DESCRIPTION
Uses commit ID from build state for uploading to GitHub code scanning instead of reading direct from environment variable