### PR TITLE
Disable major .NET SDK updates in test global.json files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,22 @@
                 "patch"
             ],
             "enabled": false
+        },
+        {
+            "description": "Disable major .NET SDK updates in test global.json files",
+            "matchManagers": [
+                "nuget"
+            ],
+            "matchPackageNames": [
+                "dotnet-sdk"
+            ],
+            "matchFileNames": [
+                "tests/**/global.json"
+            ],
+            "matchUpdateTypes": [
+                "major"
+            ],
+            "enabled": false
         }
     ]
 }


### PR DESCRIPTION
Disable major .NET SDK updates in `global.json` files of test projects, since we have individual test projects for every supported major .NET version