### PR TITLE
Build on GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,54 @@
+name: CI Build
+on:
+  # Trigger the workflow on pushes to the master or develop branch, ignoring changes to /docs
+  push:
+    branches: 
+      - develop
+      - master
+      - release/**
+    tags:
+      - "*"
+jobs:
+  # Build
+  Build:
+    name: Build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get the sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          lfs: true
+      - name: Install .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          # .NET 5 required for GitVersion
+          dotnet-version: |
+            5.x
+            8.x
+            9.x
+            10.x
+      # Ubuntu 24.04 does not have Mono installed, which is required for Cake.Recipe
+      - name: Install Mono
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
+      - name: Build
+        run: ./build.sh --target=CI --verbosity=diagnostic
+        shell: bash
+        env:
+          AZURE_PASSWORD: ${{ secrets.AZURE_PASSWORD }}
+          AZURE_SOURCE: ${{ secrets.AZURE_SOURCE }}
+          AZURE_USER: ${{ secrets.AZURE_USER }}
+          GITHUB_PAT: ${{ secrets.GH_TOKEN }}
+          GPR_SOURCE: ${{ secrets.GPR_SOURCE }}
+          GPR_API_KEY: ${{ secrets.GPR_API_KEY }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_SOURCE: "https://api.nuget.org/v3/index.json"
+      - name: Publish NuGet package as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: warn
+          name: NuGet Package
+          path: ./BuildArtifacts/Packages/NuGet/

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,6 +1,6 @@
 name: CI Build
 on:
-  # Trigger the workflow on pushes to the master or develop branch, ignoring changes to /docs
+  # Trigger the workflow on pushes to develop/master/release branches and on tag pushes
   push:
     branches: 
       - develop

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,5 +1,5 @@
-name: Build and tests
-on: [push, pull_request]
+name: PR Build
+on: [pull_request]
 jobs:
   # Build
   Build:

--- a/recipe.cake
+++ b/recipe.cake
@@ -17,7 +17,9 @@ BuildParameters.SetParameters(
     solutionFilePath: "./Cake.Frosting.Issues.Recipe/Cake.Frosting.Issues.Recipe.sln",
     shouldRunInspectCode: false, // Currently failing on AppVeyor since .NET 9 update
     shouldRunDotNetPack: true,
-    shouldGenerateDocumentation: false);
+    shouldGenerateDocumentation: false,
+    preferredBuildProviderType: BuildProviderType.GitHubActions,
+    preferredBuildAgentOperatingSystem: PlatformFamily.Linux);
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
Run builds for publishing NuGet packages on GitHub Actions instead of AppVeyor. Also splits workflows for CI and PR build.